### PR TITLE
Refactor toggle switch markup

### DIFF
--- a/local/modules/qwelp.site_settings/context.js
+++ b/local/modules/qwelp.site_settings/context.js
@@ -252,34 +252,34 @@ const App = () => {
                                     </div>
 
                                     <div className="flex items-center gap-4">
-                                        <label className="flex items-center cursor-pointer">
-                                            <div className="relative">
+                                        <label className="toggle-wrapper">
+                                            <div className="toggle-relative">
                                                 <input
                                                     type="checkbox"
                                                     checked={useCustomHeadingsFont}
                                                     onChange={() => setUseCustomHeadingsFont(!useCustomHeadingsFont)}
-                                                    className="sr-only"
+                                                    className="toggle-input"
                                                 />
-                                                <div className={`block w-14 h-8 rounded-full ${useCustomHeadingsFont ? 'bg-blue-500' : 'bg-gray-300'}`}></div>
-                                                <div className={`dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition ${useCustomHeadingsFont ? 'transform translate-x-6' : ''}`}></div>
+                                                <div className="toggle-bg"></div>
+                                                <div className="toggle-dot"></div>
                                             </div>
-                                            <span className="ml-3">Другой шрифт заголовков</span>
+                                            <span className="toggle-text">Другой шрифт заголовков</span>
                                         </label>
                                     </div>
 
                                     <div className="flex items-center gap-4">
-                                        <label className="flex items-center cursor-pointer">
-                                            <div className="relative">
+                                        <label className="toggle-wrapper">
+                                            <div className="toggle-relative">
                                                 <input
                                                     type="checkbox"
                                                     checked={useSelfHostedFonts}
                                                     onChange={() => setUseSelfHostedFonts(!useSelfHostedFonts)}
-                                                    className="sr-only"
+                                                    className="toggle-input"
                                                 />
-                                                <div className={`block w-14 h-8 rounded-full ${useSelfHostedFonts ? 'bg-blue-500' : 'bg-gray-300'}`}></div>
-                                                <div className={`dot absolute left-1 top-1 bg-white w-6 h-6 rounded-full transition ${useSelfHostedFonts ? 'transform translate-x-6' : ''}`}></div>
+                                                <div className="toggle-bg"></div>
+                                                <div className="toggle-dot"></div>
                                             </div>
-                                            <span className="ml-3">Использовать SELF-HOSTED шрифты</span>
+                                            <span className="toggle-text">Использовать SELF-HOSTED шрифты</span>
                                         </label>
                                     </div>
                                 </div>

--- a/local/modules/qwelp.site_settings/install/components/qwelp/site.settings/templates/.default/style.css
+++ b/local/modules/qwelp.site_settings/install/components/qwelp/site.settings/templates/.default/style.css
@@ -179,32 +179,47 @@
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    cursor: pointer;
     flex-wrap: wrap;
 }
-.option-input[type="checkbox"] + .toggle-label {
-    width: 3rem;
-    height: 1.5rem;
+.toggle-relative {
+    position: relative;
+}
+.toggle-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+.toggle-bg {
+    width: 3.5rem;
+    height: 2rem;
     border-radius: 9999px;
     background: var(--site-settings-secondary-color);
-    position: relative;
-    cursor: pointer;
-    margin: 0;
-    padding: 0;
 }
-.option-input[type="checkbox"] + .toggle-label::after {
-    content: "";
+.toggle-dot {
     position: absolute;
     top: 0.25rem;
     left: 0.25rem;
-    width: 1rem;
-    height: 1rem;
+    width: 1.5rem;
+    height: 1.5rem;
     background: #fff;
-    border-radius: 50%;
+    border-radius: 9999px;
     transition: transform var(--site-settings-transition-speed);
 }
-.option-input[type="checkbox"]:checked + .toggle-label::after {
-    transform: translateX(1.25rem);
+.toggle-input:checked + .toggle-bg {
     background: var(--site-settings-primary-color);
+}
+.toggle-input:checked + .toggle-bg + .toggle-dot {
+    transform: translateX(1.5rem);
+}
+.toggle-text {
+    margin-left: 0.75rem;
 }
 
 /* Селект */

--- a/local/modules/qwelp.site_settings/install/components/qwelp/site.settings/templates/.default/template.php
+++ b/local/modules/qwelp.site_settings/install/components/qwelp/site.settings/templates/.default/template.php
@@ -130,18 +130,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                     <?php
                                     $type = $setting['type'];
                                     if ($type === 'checkbox'): ?>
-                                        <div class="toggle-wrapper">
-                                            <input
-                                                    type="checkbox"
-                                                    id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                    name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                    class="option-input"
-                                            >
-                                            <label
-                                                    for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                    class="option-label toggle-label"
-                                            ></label>
-                                        </div>
+                                        <label class="toggle-wrapper">
+                                            <div class="toggle-relative">
+                                                <input
+                                                        type="checkbox"
+                                                        id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                        name="<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                        class="toggle-input"
+                                                >
+                                                <div class="toggle-bg"></div>
+                                                <div class="toggle-dot"></div>
+                                            </div>
+                                        </label>
                                     <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                         <div class="radio-options-wrapper">
                                             <?php foreach ($setting['options'] as $opt): ?>
@@ -249,18 +249,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                         <?php
                                         $type = $setting['type'];
                                         if ($type === 'checkbox'): ?>
-                                            <div class="toggle-wrapper">
-                                                <input
-                                                        type="checkbox"
-                                                        id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                        name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                        class="option-input"
-                                                >
-                                                <label
-                                                        for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                        class="option-label toggle-label"
-                                                ></label>
-                                            </div>
+                                            <label class="toggle-wrapper">
+                                                <div class="toggle-relative">
+                                                    <input
+                                                            type="checkbox"
+                                                            id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                            name="<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                            class="toggle-input"
+                                                    >
+                                                    <div class="toggle-bg"></div>
+                                                    <div class="toggle-dot"></div>
+                                                </div>
+                                            </label>
                                         <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                             <div class="radio-options-wrapper">
                                                 <?php foreach ($setting['options'] as $opt): ?>
@@ -402,18 +402,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                                 <?php
                                                 $type = $setting['type'];
                                                 if ($type === 'checkbox'): ?>
-                                                    <div class="toggle-wrapper">
-                                                        <input
-                                                                type="checkbox"
-                                                                id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                class="option-input"
-                                                        >
-                                                        <label
-                                                                for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                class="option-label toggle-label"
-                                                        ></label>
-                                                    </div>
+                                                    <label class="toggle-wrapper">
+                                                        <div class="toggle-relative">
+                                                            <input
+                                                                    type="checkbox"
+                                                                    id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                    name="<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                    class="toggle-input"
+                                                            >
+                                                            <div class="toggle-bg"></div>
+                                                            <div class="toggle-dot"></div>
+                                                        </div>
+                                                    </label>
                                                 <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                                     <div class="radio-options-wrapper">
                                                         <?php foreach ($setting['options'] as $opt): ?>
@@ -521,18 +521,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                                     <?php
                                                     $type = $setting['type'];
                                                     if ($type === 'checkbox'): ?>
-                                                        <div class="toggle-wrapper">
-                                                            <input
-                                                                    type="checkbox"
-                                                                    id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                    name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                    class="option-input"
-                                                            >
-                                                            <label
-                                                                    for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                    class="option-label toggle-label"
-                                                            ></label>
-                                                        </div>
+                                                        <label class="toggle-wrapper">
+                                                            <div class="toggle-relative">
+                                                                <input
+                                                                        type="checkbox"
+                                                                        id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                        name="<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                        class="toggle-input"
+                                                                >
+                                                                <div class="toggle-bg"></div>
+                                                                <div class="toggle-dot"></div>
+                                                            </div>
+                                                        </label>
                                                     <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                                         <div class="radio-options-wrapper">
                                                             <?php foreach ($setting['options'] as $opt): ?>
@@ -660,18 +660,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                                         <?php
                                                         $type = $setting['type'];
                                                         if ($type === 'checkbox'): ?>
-                                                            <div class="toggle-wrapper">
-                                                                <input
-                                                                        type="checkbox"
-                                                                        id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                        name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                        class="option-input"
-                                                                >
-                                                                <label
-                                                                        for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                        class="option-label toggle-label"
-                                                                ></label>
-                                                            </div>
+                                                            <label class="toggle-wrapper">
+                                                                <div class="toggle-relative">
+                                                                    <input
+                                                                            type="checkbox"
+                                                                            id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                            name="<?= htmlspecialcharsbx($setting['code']) ?>"
+                                                                            class="toggle-input"
+                                                                    >
+                                                                    <div class="toggle-bg"></div>
+                                                                    <div class="toggle-dot"></div>
+                                                                </div>
+                                                            </label>
                                                         <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                                             <div class="radio-options-wrapper">
                                                                 <?php foreach ($setting['options'] as $opt): ?>
@@ -787,18 +787,18 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                                                 <?php
                                                                 $type = $setting['type'];
                                                                 if ($type === 'checkbox'): ?>
-                                                                    <div class="toggle-wrapper">
-                                                                        <input
-                                                                                type="checkbox"
-                                                                                id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                                name="<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                                class="option-input"
-                                                                        >
-                                                                        <label
-                                                                                for="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
-                                                                                class="option-label toggle-label"
-                                                                        ></label>
-                                                                    </div>
+                                                                    <label class="toggle-wrapper">
+                                                                        <div class="toggle-relative">
+                                                                            <input
+        type="checkbox"
+        id="setting_<?= htmlspecialcharsbx($setting['code']) ?>"
+        name="<?= htmlspecialcharsbx($setting['code']) ?>"
+        class="toggle-input"
+                                                                            >
+                                                                            <div class="toggle-bg"></div>
+                                                                            <div class="toggle-dot"></div>
+                                                                        </div>
+                                                                    </label>
                                                                 <?php elseif ($type === 'radio' && is_array($setting['options'])): ?>
                                                                     <div class="radio-options-wrapper">
                                                                         <?php foreach ($setting['options'] as $opt): ?>


### PR DESCRIPTION
## Summary
- restyle toggle switch markup in template
- update toggle styles to pure CSS
- use new toggle styles in React demo

## Testing
- `php -l local/modules/qwelp.site_settings/install/components/qwelp/site.settings/templates/.default/template.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840235563f08326a476485bed1b172e