### PR TITLE
Handle width percent for settings items

### DIFF
--- a/bitrix/components/qwelp/site.settings/templates/.default/style.css
+++ b/bitrix/components/qwelp/site.settings/templates/.default/style.css
@@ -119,9 +119,19 @@
     display: flex;
     flex-direction: column;
     border-bottom: 1px dotted #ddd;
+    box-sizing: border-box;
+    flex: 0 0 100%;
 }
 .setting-item:last-child {
     border-bottom: none;
+}
+.hidden-setting-item {
+    padding: 0.5rem 0;
+    display: flex;
+    flex-direction: column;
+    border-bottom: 1px dotted #ddd;
+    box-sizing: border-box;
+    flex: 0 0 100%;
 }
 .setting-label {
     font-weight: bold;
@@ -319,7 +329,8 @@
 /* Стилизация разделов и drag&drop */
 .settings-subsection {
     display: flex;
-    flex-direction: column;
+    flex-wrap: wrap;
+    flex-direction: row;
     padding: 0.5rem 0.75rem;
     border-bottom: 1px solid #e5e5e5;
     background-color: #fff;
@@ -378,6 +389,7 @@
     margin-bottom: 0.5rem;
     display: flex;
     align-items: center;
+    flex-basis: 100%;
 }
 .subsection-header .drag-handle {
     margin-left: 0.5rem;

--- a/bitrix/components/qwelp/site.settings/templates/.default/template.php
+++ b/bitrix/components/qwelp/site.settings/templates/.default/template.php
@@ -111,9 +111,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                         <!-- 1) Level 1 (видимые) -->
                         <?php if (!empty($visibleLevel1)): ?>
                             <?php foreach ($visibleLevel1 as $setting): ?>
+                                <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                 <div class="setting-item"
                                      data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                      data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                     style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                 >
                                     <div class="setting-label">
                                         <?= htmlspecialcharsbx($setting['label']) ?>
@@ -230,9 +232,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                             </div>
                             <div id="hidden-level1-<?= htmlspecialcharsbx($sec1['id']) ?>" class="collapse-content">
                                 <?php foreach ($hiddenLevel1 as $setting): ?>
+                                    <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                     <div class="hidden-setting-item"
                                          data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                          data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                         style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                     >
                                         <div class="setting-label">
                                             <?= htmlspecialcharsbx($setting['label']) ?>
@@ -383,9 +387,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                     <!-- 2.1) Настройки второго уровня (видимые) -->
                                     <?php if (!empty($visibleLevel2)): ?>
                                         <?php foreach ($visibleLevel2 as $setting): ?>
+                                            <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                             <div class="setting-item"
                                                  data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                                  data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                                 style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                             >
                                                 <div class="setting-label">
                                                     <?= htmlspecialcharsbx($setting['label']) ?>
@@ -502,9 +508,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                         </div>
                                         <div id="hidden-level2-<?= htmlspecialcharsbx($sec2['id']) ?>" class="collapse-content">
                                             <?php foreach ($hiddenLevel2 as $setting): ?>
+                                                <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                                 <div class="hidden-setting-item"
                                                      data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                                      data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                                     style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                                 >
                                                     <div class="setting-label">
                                                         <?= htmlspecialcharsbx($setting['label']) ?>
@@ -641,9 +649,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
 
                                             <?php if (!empty($sec3['settings'])): ?>
                                                 <?php foreach ($sec3['settings'] as $setting): ?>
+                                                    <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                                     <div class="setting-item"
                                                          data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                                          data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                                         style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                                     >
                                                         <div class="setting-label">
                                                             <?= htmlspecialcharsbx($setting['label']) ?>
@@ -768,9 +778,11 @@ Asset::getInstance()->addJs($this->GetFolder() . '/script.js');
                                                     </div>
                                                     <?php if (!empty($sec3['settings'])): ?>
                                                         <?php foreach ($sec3['settings'] as $setting): ?>
+                                                            <?php $width = !empty($setting['percent']) ? $setting['percent'] : '100%'; ?>
                                                             <div class="hidden-setting-item"
                                                                  data-setting-code="<?= htmlspecialcharsbx($setting['code']) ?>"
                                                                  data-setting-type="<?= htmlspecialcharsbx($setting['type']) ?>"
+                                                                 style="flex-basis: <?= htmlspecialcharsbx($width) ?>; max-width: <?= htmlspecialcharsbx($width) ?>;"
                                                             >
                                                                 <div class="setting-label">
                                                                     <?= htmlspecialcharsbx($setting['label']) ?>


### PR DESCRIPTION
## Summary
- make subsections flex-wrap so items can fit custom widths
- ensure headers span full width
- default `setting-item` and `hidden-setting-item` take full width
- allow template items to set flex-basis style from `percent` parameter

## Testing
- `php -l bitrix/components/qwelp/site.settings/templates/.default/template.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68402d8def7c83268038a6cc095fb935